### PR TITLE
Parallel ETT: Add identifiers to skip list elements

### DIFF
--- a/src/dynamic_trees/parallel_euler_tour_tree/src/euler_tour_sequence.hpp
+++ b/src/dynamic_trees/parallel_euler_tour_tree/src/euler_tour_sequence.hpp
@@ -14,7 +14,7 @@ class Element : public parallel_skip_list::ElementBase<Element> {
   explicit Element(std::pair<int, int> id, size_t random_int)
     : parallel_skip_list::ElementBase<Element>{random_int} {}
 
-  // If this element represents a vertex v, then id == (v, v).  Otherwise if
+  // If this element represents a vertex v, then id == (v, v). Otherwise if
   // this element represents a directed edge (u, v), then id == (u,v).
   std::pair<int, int> id;
   // If this element represents edge (u, v), `twin` should point towards (v, u).

--- a/src/dynamic_trees/parallel_euler_tour_tree/src/euler_tour_sequence.hpp
+++ b/src/dynamic_trees/parallel_euler_tour_tree/src/euler_tour_sequence.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include <sequence/parallel_skip_list/include/skip_list_base.hpp>
 
 namespace parallel_euler_tour_tree {
@@ -9,9 +11,12 @@ namespace _internal {
 class Element : public parallel_skip_list::ElementBase<Element> {
  public:
   Element() : parallel_skip_list::ElementBase<Element>{} {}
-  explicit Element(size_t random_int)
+  explicit Element(std::pair<int, int> id, size_t random_int)
     : parallel_skip_list::ElementBase<Element>{random_int} {}
 
+  // If this element represents a vertex v, then id == (v, v).  Otherwise if
+  // this element represents a directed edge (u, v), then id == (u,v).
+  std::pair<int, int> id;
   // If this element represents edge (u, v), `twin` should point towards (v, u).
   Element* twin_{nullptr};
   // When batch splitting, we mark this as `true` for an edge that we will

--- a/src/dynamic_trees/parallel_euler_tour_tree/src/euler_tour_sequence.hpp
+++ b/src/dynamic_trees/parallel_euler_tour_tree/src/euler_tour_sequence.hpp
@@ -12,11 +12,11 @@ class Element : public parallel_skip_list::ElementBase<Element> {
  public:
   Element() : parallel_skip_list::ElementBase<Element>{} {}
   explicit Element(std::pair<int, int> id, size_t random_int)
-    : parallel_skip_list::ElementBase<Element>{random_int} {}
+    : parallel_skip_list::ElementBase<Element>{random_int}, id_{id} {}
 
   // If this element represents a vertex v, then id == (v, v). Otherwise if
   // this element represents a directed edge (u, v), then id == (u,v).
-  std::pair<int, int> id;
+  std::pair<int, int> id_;
   // If this element represents edge (u, v), `twin` should point towards (v, u).
   Element* twin_{nullptr};
   // When batch splitting, we mark this as `true` for an edge that we will

--- a/src/dynamic_trees/parallel_euler_tour_tree/src/euler_tour_tree.cpp
+++ b/src/dynamic_trees/parallel_euler_tour_tree/src/euler_tour_tree.cpp
@@ -53,7 +53,7 @@ EulerTourTree::EulerTourTree(int num_vertices)
   Element::Initialize();
   vertices_ = pbbs::new_array_no_init<Element>(num_vertices_);
   parallel_for (int i = 0; i < num_vertices_; i++) {
-    new (&vertices_[i]) Element{randomness_.ith_rand(i)};
+    new (&vertices_[i]) Element{make_pair(i, i), randomness_.ith_rand(i)};
     // The Euler tour on a vertex v (a singleton tree) is simply (v, v).
     Element::Join(&vertices_[i], &vertices_[i]);
   }
@@ -72,9 +72,9 @@ bool EulerTourTree::IsConnected(int u, int v) const {
 
 void EulerTourTree::Link(int u, int v) {
   Element* uv{allocator.alloc()};
-  new (uv) Element{randomness_.ith_rand(0)};
+  new (uv) Element{make_pair(u, v), randomness_.ith_rand(0)};
   Element* vu = allocator.alloc();
-  new (vu) Element{randomness_.ith_rand(1)};
+  new (vu) Element{make_pair(v, u), randomness_.ith_rand(1)};
   randomness_ = randomness_.next();
   uv->twin_ = vu;
   vu->twin_ = uv;
@@ -126,9 +126,9 @@ void EulerTourTree::BatchLink(pair<int, int>* links, int len) {
     // allocate edge element
     if (u < v) {
       Element* uv{allocator.alloc()};
-      new (uv) Element{randomness_.ith_rand(2 * i)};
+      new (uv) Element{make_pair(u, v), randomness_.ith_rand(2 * i)};
       Element* vu{allocator.alloc()};
-      new (vu) Element{randomness_.ith_rand(2 * i + 1)};
+      new (vu) Element{make_pair(v, u), randomness_.ith_rand(2 * i + 1)};
       uv->twin_ = vu;
       vu->twin_ = uv;
       edges_.Insert(u, v, uv);


### PR DESCRIPTION
for reference only, do not merge

# Changes

When we have a pointer to a skip list element, it's useful to be able to tell what vertex or edge that element represents. This PR adds identifiers to each skip list element.

# Tests

it compiles, did not test

